### PR TITLE
Modifly useless pointer order

### DIFF
--- a/Repo/mock_order_repo.go
+++ b/Repo/mock_order_repo.go
@@ -10,7 +10,7 @@ type OrderRepoMock struct {
 	mock.Mock
 }
 
-func (m *OrderRepoMock) SaveCreateOrder(order *entities.Order) (*entities.Order, error) {
+func (m *OrderRepoMock) SaveCreateOrder(order entities.Order) (*entities.Order, error) {
 	args := m.Called(order)
 	if args.Get(0) != nil {
 		return args.Get(0).(*entities.Order), args.Error(1)
@@ -26,7 +26,7 @@ func (m *OrderRepoMock) GetOrderForUpdateStatus(id uuid.UUID) (*entities.Order, 
 	return nil, args.Error(1)
 }
 
-func (m *OrderRepoMock) SaveUpdateStatusOrder(o *entities.Order) (*entities.Order, error) {
+func (m *OrderRepoMock) SaveUpdateStatusOrder(o entities.Order) (*entities.Order, error) {
 	args := m.Called(o)
 	if args.Get(0) != nil {
 		return args.Get(0).(*entities.Order), args.Error(1)

--- a/Repo/mock_transaction_repo.go
+++ b/Repo/mock_transaction_repo.go
@@ -25,7 +25,7 @@ func (m *TransactionRepoMock) SaveGetAllTransaction() ([]*entities.Transaction, 
 	return nil, args.Error(1)
 }
 
-func (m *TransactionRepoMock) GetTransactionToCreateOrder(order *entities.Order) (*entities.Transaction, error) {
+func (m *TransactionRepoMock) GetTransactionToCreateOrder(order entities.Order) (*entities.Transaction, error) {
 	args := m.Called(order)
 	if args.Get(0) != nil {
 		return args.Get(0).(*entities.Transaction), args.Error(1)

--- a/Repo/order.go
+++ b/Repo/order.go
@@ -15,7 +15,7 @@ func NewOrderRepo(db *gorm.DB) OrderRepoI {
 	return &OrderRepo{DB: db}
 }
 
-func (r *OrderRepo) SaveCreateOrder(order *entities.Order) (*entities.Order, error) {
+func (r *OrderRepo) SaveCreateOrder(order entities.Order) (*entities.Order, error) {
 	createdOrder := models.OrderToGormOrder(order)
 	err := r.DB.Create(&createdOrder).Error
 	if err != nil {
@@ -35,7 +35,7 @@ func (r *OrderRepo) GetOrderForUpdateStatus(id uuid.UUID) (*entities.Order, erro
 	return orderEntity, nil
 }
 
-func (r *OrderRepo) SaveUpdateStatusOrder(o *entities.Order) (*entities.Order, error) {
+func (r *OrderRepo) SaveUpdateStatusOrder(o entities.Order) (*entities.Order, error) {
 	updatedOrder := models.OrderToGormOrder(o)
 	err := r.DB.Save(&updatedOrder).Error
 	if err != nil {

--- a/Repo/order_interface.go
+++ b/Repo/order_interface.go
@@ -6,8 +6,8 @@ import (
 )
 
 type OrderRepoI interface {
-	SaveCreateOrder(order *entities.Order) (*entities.Order, error)
+	SaveCreateOrder(order entities.Order) (*entities.Order, error)
 	GetOrderForUpdateStatus(id uuid.UUID) (*entities.Order, error)
-	SaveUpdateStatusOrder(o *entities.Order) (*entities.Order, error)
+	SaveUpdateStatusOrder(o entities.Order) (*entities.Order, error)
 	SaveGetAllOrders() ([]*entities.Order, error)
 }

--- a/Repo/transaction.go
+++ b/Repo/transaction.go
@@ -37,7 +37,7 @@ func (r *TransactionRepo) SaveGetAllTransaction() ([]*entities.Transaction, erro
 	return transaction, nil
 }
 
-func (r *TransactionRepo) GetTransactionToCreateOrder(order *entities.Order) (*entities.Transaction, error) {
+func (r *TransactionRepo) GetTransactionToCreateOrder(order entities.Order) (*entities.Transaction, error) {
 	var transaction models.Transaction
 	err := r.db.Model(&models.Transaction{}).Where("transaction_id = ?", order.TransactionId).
 		Preload("Items.Product").First(&transaction).Error

--- a/Repo/transaction_interface.go
+++ b/Repo/transaction_interface.go
@@ -5,5 +5,5 @@ import "awesomeProject/entities"
 type TransactionRepoI interface {
 	SaveCreateTransaction(transaction *entities.Transaction) (*entities.Transaction, error)
 	SaveGetAllTransaction() ([]*entities.Transaction, error)
-	GetTransactionToCreateOrder(order *entities.Order) (*entities.Transaction, error)
+	GetTransactionToCreateOrder(order entities.Order) (*entities.Transaction, error)
 }

--- a/Usecase/usecae_order_interface.go
+++ b/Usecase/usecae_order_interface.go
@@ -6,7 +6,7 @@ import (
 )
 
 type OrderUseCaseI interface {
-	CreateOrder(order *entities.Order) (*entities.Order, error)
-	UpdateStatusOrder(o *entities.Order, id uuid.UUID) (*entities.Order, error)
+	CreateOrder(order entities.Order) (*entities.Order, error)
+	UpdateStatusOrder(o entities.Order, id uuid.UUID) (*entities.Order, error)
 	GetAllOrders() ([]*entities.Order, error)
 }

--- a/Usecase/usecase_order.go
+++ b/Usecase/usecase_order.go
@@ -20,7 +20,7 @@ func NewOrderUseCase(o Repo.OrderRepoI, s Repo.StockRepoI, t Repo.TransactionRep
 	}
 }
 
-func (u *OrderUseCase) CreateOrder(o *entities.Order) (*entities.Order, error) {
+func (u *OrderUseCase) CreateOrder(o entities.Order) (*entities.Order, error) {
 	transaction, err := u.TransactionRepo.GetTransactionToCreateOrder(o)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func (u *OrderUseCase) CreateOrder(o *entities.Order) (*entities.Order, error) {
 	return createdOrder, nil
 }
 
-func (u *OrderUseCase) UpdateStatusOrder(o *entities.Order, id uuid.UUID) (*entities.Order, error) {
+func (u *OrderUseCase) UpdateStatusOrder(o entities.Order, id uuid.UUID) (*entities.Order, error) {
 	order, err := u.OrderRepo.GetOrderForUpdateStatus(id)
 	if err != nil {
 		return nil, err

--- a/Usecase/usecase_order_test.go
+++ b/Usecase/usecase_order_test.go
@@ -23,12 +23,17 @@ func TestOrderUseCase_CreateOrder(t *testing.T) {
 		},
 		TotalPrice: 1100,
 	}
-	order := &entities.Order{
+	order := entities.Order{
 		OrderId:       uuid.New(),
 		TransactionId: transaction.TransactionId,
 	}
+	orderInitStatus := entities.Order{
+		OrderId:       order.OrderId,
+		TransactionId: transaction.TransactionId,
+		Status:        "New",
+	}
 
-	orderInvalidStatusInit := &entities.Order{
+	orderInvalidStatusInit := entities.Order{
 		OrderId:       uuid.New(),
 		TransactionId: transaction.TransactionId,
 		Status:        "Processing",
@@ -37,11 +42,11 @@ func TestOrderUseCase_CreateOrder(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mockTransactionRepo.On("GetTransactionToCreateOrder", order).Return(transaction, nil).Once()
 		mockStockRepo.On("CheckStockToCreateOrder", transaction).Return(nil).Once()
-		mockOrderRepo.On("SaveCreateOrder", order).Return(order, nil).Once()
+		mockOrderRepo.On("SaveCreateOrder", orderInitStatus).Return(&orderInitStatus, nil).Once()
 		result, err := service.CreateOrder(order)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
-		assert.Equal(t, order.TransactionId, result.TransactionId)
+		assert.Equal(t, &orderInitStatus, result)
 		mockOrderRepo.AssertExpectations(t)
 		mockTransactionRepo.AssertExpectations(t)
 		mockStockRepo.AssertExpectations(t)
@@ -81,7 +86,7 @@ func TestOrderUseCase_CreateOrder(t *testing.T) {
 	t.Run("Cannot save create order", func(t *testing.T) {
 		mockTransactionRepo.On("GetTransactionToCreateOrder", order).Return(transaction, nil).Once()
 		mockStockRepo.On("CheckStockToCreateOrder", transaction).Return(nil).Once()
-		mockOrderRepo.On("SaveCreateOrder", order).Return(nil, errors.New("cannot save create order")).Once()
+		mockOrderRepo.On("SaveCreateOrder", orderInitStatus).Return(nil, errors.New("cannot save create order")).Once()
 		result, err := service.CreateOrder(order)
 		assert.Error(t, err)
 		assert.Nil(t, result)
@@ -102,12 +107,12 @@ func TestOrderUseCase_UpdateStatus(t *testing.T) {
 		TransactionId: uuid.New(),
 		Status:        "New",
 	}
-	order := &entities.Order{
+	order := entities.Order{
 		OrderId:       getOrder.OrderId,
 		TransactionId: getOrder.TransactionId,
 		Status:        "Paid",
 	}
-	orderInvalidStatus := &entities.Order{
+	orderInvalidStatus := entities.Order{
 		OrderId:       getOrder.OrderId,
 		TransactionId: getOrder.TransactionId,
 		Status:        "Processing",
@@ -115,11 +120,11 @@ func TestOrderUseCase_UpdateStatus(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		mockOrderRepo.On("GetOrderForUpdateStatus", getOrder.OrderId).Return(getOrder, nil).Once()
-		mockOrderRepo.On("SaveUpdateStatusOrder", order).Return(order, nil).Once()
+		mockOrderRepo.On("SaveUpdateStatusOrder", order).Return(&order, nil).Once()
 		result, err := service.UpdateStatusOrder(order, order.OrderId)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
-		assert.Equal(t, order, result)
+		assert.Equal(t, &order, result)
 		mockOrderRepo.AssertExpectations(t)
 	})
 

--- a/entities/Order.go
+++ b/entities/Order.go
@@ -12,43 +12,42 @@ type Order struct {
 	Status        string
 }
 
-func (o *Order) ChangeStatus(status string) (*Order, error) {
-	order := &Order{TransactionId: o.TransactionId, OrderId: o.OrderId, Status: o.Status}
+func (o Order) ChangeStatus(status string) (Order, error) {
 	if o.Status == "" {
-		return nil, errors.New("invalid o status")
+		return o, errors.New("invalid o status")
 	}
 	if o.Status == status {
-		return order, nil
+		return o, nil
 	}
 	switch o.Status {
 
 	case "New":
 		if status == "Paid" {
-			order.Status = status
-			return order, nil
+			o.Status = status
+			return o, nil
 		}
 
 	case "Paid":
 		if status == "Processing" {
-			order.Status = status
-			return order, nil
+			o.Status = status
+			return o, nil
 		}
 		if status == "Done" {
-			order.Status = status
-			return order, nil
+			o.Status = status
+			return o, nil
 		}
 
 	case "Processing":
 		if status == "Done" {
-			order.Status = status
-			return order, nil
+			o.Status = status
+			return o, nil
 		}
 	}
 
-	return order, fmt.Errorf("%w: from %s to %s", errors.New("invalid o status"), o.Status, status)
+	return o, fmt.Errorf("%w: from %s to %s", errors.New("invalid o status"), o.Status, status)
 }
 
-func (o *Order) InitStatus() (*Order, error) {
+func (o Order) InitStatus() (Order, error) {
 	switch o.Status {
 	case "":
 		o.Status = "New"

--- a/models/Order.go
+++ b/models/Order.go
@@ -26,8 +26,8 @@ func (o *Order) ToOrder() *entities.Order {
 	}
 }
 
-func OrderToGormOrder(o *entities.Order) *Order {
-	return &Order{
+func OrderToGormOrder(o entities.Order) Order {
+	return Order{
 		OrderId:       o.OrderId,
 		TransactionID: o.TransactionId,
 		Status:        o.Status,

--- a/payload/OrderJson.go
+++ b/payload/OrderJson.go
@@ -19,14 +19,14 @@ type ResponseOrder struct {
 	Status        string    `json:"status"`
 }
 
-func (p *RequestCreateOrder) ToOrder() *entities.Order {
-	return &entities.Order{
+func (p *RequestCreateOrder) ToOrder() entities.Order {
+	return entities.Order{
 		TransactionId: p.TransactionId,
 	}
 }
 
-func (p *RequestUpdateStatusOrder) ToOrder() *entities.Order {
-	return &entities.Order{
+func (p *RequestUpdateStatusOrder) ToOrder() entities.Order {
+	return entities.Order{
 		Status: p.Status,
 	}
 }


### PR DESCRIPTION
- Fix function order usecase,repo parameter receive non-pointer variable
- Fix function transaction repo parameter receive non-pointer variable
- Fix Function entity order convert to model order --> return non-pointer variable
- Fix Function payload order convert to entity order --> return non-pointer variable
- Fix unit tests order usecase to reflect the changes
- Fix mock order to reflect the changes interface order repo
- Fix mock transaction to reflect the changes interface transaction repo
- Fix function Init status and change status in entity order to return non-pointer variable